### PR TITLE
사용자는 회원가입 시 아이디/비밀번호에 대한 유효성 검사를 해야 한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation "org.springframework.boot:spring-boot-starter-security"
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/eungchaeungcha/juang/JuangApplication.java
+++ b/src/main/java/com/eungchaeungcha/juang/JuangApplication.java
@@ -2,10 +2,8 @@ package com.eungchaeungcha.juang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class JuangApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/eungchaeungcha/juang/common/CommonErrorCode.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/CommonErrorCode.java
@@ -1,0 +1,16 @@
+package com.eungchaeungcha.juang.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/eungchaeungcha/juang/common/ErrorCode.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.eungchaeungcha.juang.common;
+
+
+import org.springframework.http.HttpStatus;
+
+
+public interface ErrorCode {
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/eungchaeungcha/juang/common/ErrorResponse.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.eungchaeungcha.juang.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    public record ValidationError(String field, String message) {
+        public static ValidationError of(final FieldError fieldError) {
+            return new ValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.eungchaeungcha.juang.common;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(BindException e, ErrorCode errorCode) {
+        List<ErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .errors(validationErrorList)
+                .build();
+    }
+}

--- a/src/main/java/com/eungchaeungcha/juang/config/JpaAuditingConfig.java
+++ b/src/main/java/com/eungchaeungcha/juang/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.eungchaeungcha.juang.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/eungchaeungcha/juang/controller/AuthenticationController.java
+++ b/src/main/java/com/eungchaeungcha/juang/controller/AuthenticationController.java
@@ -4,6 +4,7 @@ import com.eungchaeungcha.juang.dto.AuthenticationRequestDTO;
 import com.eungchaeungcha.juang.dto.AuthenticationResponseDTO;
 import com.eungchaeungcha.juang.dto.RegisterRequestDTO;
 import com.eungchaeungcha.juang.service.AuthenticationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +21,7 @@ public class AuthenticationController {
 
     @PostMapping("/register")
     public ResponseEntity<AuthenticationResponseDTO> register(
-            @RequestBody RegisterRequestDTO request
+            @Valid @RequestBody RegisterRequestDTO request
     ) {
         return ResponseEntity.ok(authenticationService.register(request));
     }

--- a/src/main/java/com/eungchaeungcha/juang/dto/AuthenticationResponseDTO.java
+++ b/src/main/java/com/eungchaeungcha/juang/dto/AuthenticationResponseDTO.java
@@ -1,8 +1,6 @@
 package com.eungchaeungcha.juang.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.NoArgsConstructor;
 
 @Builder
 public record AuthenticationResponseDTO(

--- a/src/main/java/com/eungchaeungcha/juang/dto/RegisterRequestDTO.java
+++ b/src/main/java/com/eungchaeungcha/juang/dto/RegisterRequestDTO.java
@@ -1,11 +1,18 @@
 package com.eungchaeungcha.juang.dto;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 
 @Builder
 public record RegisterRequestDTO(
+        @Pattern(regexp = "^[a-z0-9]{6,12}$", message = "아이디는 영어 소문자와 숫자로 이루어진 6~12자여야 합니다.")
         String username,
+
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])|(?=.*[a-zA-Z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[!@#$%^&*]).{8,20}$",
+                message = "비밀번호는 특수문자, 영어 대/소문자, 숫자 중 2개 이상의 조합으로 8~20자여야 합니다."
+        )
         String password
 ) {
 }

--- a/src/test/java/com/eungchaeungcha/juang/TestSecurityConfig.java
+++ b/src/test/java/com/eungchaeungcha/juang/TestSecurityConfig.java
@@ -1,0 +1,36 @@
+package com.eungchaeungcha.juang;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        http
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/test").hasRole("USER")
+                        .anyRequest().authenticated());
+
+
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/test/java/com/eungchaeungcha/juang/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/eungchaeungcha/juang/controller/AuthenticationControllerTest.java
@@ -1,0 +1,153 @@
+package com.eungchaeungcha.juang.controller;
+
+
+import com.eungchaeungcha.juang.TestSecurityConfig;
+import com.eungchaeungcha.juang.common.CommonErrorCode;
+import com.eungchaeungcha.juang.config.JwtService;
+import com.eungchaeungcha.juang.dto.AuthenticationResponseDTO;
+import com.eungchaeungcha.juang.dto.RegisterRequestDTO;
+import com.eungchaeungcha.juang.service.AuthenticationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = AuthenticationController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@Import(TestSecurityConfig.class)
+public class AuthenticationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthenticationService authenticationService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private AuthenticationProvider authenticationProvider;
+
+
+    @Test
+    @DisplayName("회원가입 성공 - 유효한 아이디와 비밀번호")
+    void register_success() throws Exception {
+        //given
+        RegisterRequestDTO request = RegisterRequestDTO.builder().username("testu1").password("Password123!").build();
+
+        AuthenticationResponseDTO response = AuthenticationResponseDTO.builder().token("success token").build();
+
+        //when
+        when(authenticationService.register(any(RegisterRequestDTO.class))).thenReturn(response);        // /then
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value(response.token()));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 아이디 6자 미만")
+    void register_fail_lessUsernameLength() throws Exception {
+        // given
+        RegisterRequestDTO request = new RegisterRequestDTO("12345", "Password123!");
+
+        //when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("username"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 아이디 12자 초과")
+    void register_fail_overUsernameLength() throws Exception {
+        // given
+        RegisterRequestDTO request = new RegisterRequestDTO("1234567891234", "Password123!");
+
+        //when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("username"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 아이디 형식 오류")
+    void register_fail_invalidUsername() throws Exception {
+        // given
+        RegisterRequestDTO request = new RegisterRequestDTO("TestUser!", "Password123!");
+
+        //when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("username"))
+                .andExpect(jsonPath("$.errors[0].message").value("아이디는 영어 소문자와 숫자로 이루어진 6~12자여야 합니다."));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 비밀번호 길이 8자 미만")
+    void register_fail_lessPasswordLength() throws Exception {
+        //given
+        RegisterRequestDTO request = new RegisterRequestDTO("validuser1", "acdefg");
+
+        // when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("password"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 비밀번호 길이 20자 초과")
+    void register_fail_overPasswordLength() throws Exception {
+        //given
+        RegisterRequestDTO request = new RegisterRequestDTO("validuser1", "123456789012345678901234");
+
+        // when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("password"));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 비밀번호 형식 오류")
+    void register_fail_invalidPassword() throws Exception {
+        // given
+        RegisterRequestDTO request = new RegisterRequestDTO("validuser1", "abcdefgefefefefefe");
+
+        // when/then
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(CommonErrorCode.INVALID_PARAMETER.getMessage()))
+                .andExpect(jsonPath("$.errors[0].field").value("password"))
+                .andExpect(jsonPath("$.errors[0].message").value("비밀번호는 특수문자, 영어 대/소문자, 숫자 중 2개 이상의 조합으로 8~20자여야 합니다."));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,19 +1,9 @@
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3308/juang_db
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-        highlight_sql: true
-        use_sql_comments: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true


### PR DESCRIPTION
## ✅ 사용자는 회원가입 시 아이디/비밀번호에 대한 유효성 검사를 해야 한다.
close #3 

<br>

## ✅ 작업 내용
- @Valid 어노테이션 사용을 위해 의존성 추가
    - 빈 검증기를 이용해 객체의 제약 조건을 검증하도록 지시하는 어노테이션 @Valid 를 사용하기 위해서 LocalValidatorFactoryBean 을 빈으로 등록하도록 하였습니다.
    - 빈으로 등록하기 위해서 `spring-boot-starter-validation` 의존성을 추가하여 해당 기능들이 자동 설정되도록 하였습니다. 

- `RegisterReqeustDTO` 에 유효성 검사와 관련된 어노테이션 설정
    - `@Patteren` 어노테이션을 통해서 [다음](https://github.com/orgs/eungchaeungcha/discussions/2#discussion-7830245)과 같은 아이디와 비밀번호에 대한 유효성을 확인하도록 하였습니다.
 
        ```
        아이디 : 영어 소문자 + 숫자, 6 ~ 12자
        비밀번호 : [특수문자, 영어 대/소문자, 숫자] 2개 이상의 조합, 8 ~ 20자
        ```

- 전역 예외 처리
    - 전역적으로 `@ExceptionHandler` 를 사용할 수 있는 `@RestControllerAdvice` 를 선언하여 빈으로 등록해주었습니다. 
    - 유효성 검사 실패 시 발생하는 `MethodArgumentValidException` 에 대해 Custom 한 ErrorResponse 를 보내주기 위해서 `ResponseEntityExceptionHandler` 에 작성된 메서드를 오버라이드 해주었습니다. 
    - ErrorResponse 에는 `HttpStatusCode`, `Message`, 그리고 MethodArgumentValidException 이 발생했을 때 어떤 필드와 에러가 발생했는지 담는 `errors` 필드를 선언하였습니다. 

- 컨트롤러 테스트 작성
   - 최소한의 빈을 등록하여 간단하고 빠르게 컨트롤러 테스트를 실행할 수 있도록 `@WebMvcTest` 어노테이션을 선언하였습니다. 
      - 테스트를 위해 필요한 빈들은 `@MockitoBean`을 등록해주었습니다.  (SpringBoot 3.4.0 버전 이후로는 `MockBean` 을 지원하지 않습니다.)
   - 자동으로 설정된 `SecurityAutoConfiguration.class` 가 아닌 Custom 하게 만든 `TestSecurityConfig `가 설정되도록 해주었습니다.
   - JPA 생성과 관련된 기능이 전혀 존재하지 않아 발생하는 JPA metamodel must not be empty! 에러를 해결하기 위해서 `@EnableJpaAuditing` 을 분리해주었습니다. 
 

- 그외
   - record 에 선언된 불필요한 어노테이션을 삭제해주었습니다. (생성자)
   - test 와 관련하여 docker mysql 을 사용하도록 변경해주었습니다.    


