### PR TITLE
CORS origin 허용

### DIFF
--- a/src/main/java/com/eungchaeungcha/juang/config/WebConfig.java
+++ b/src/main/java/com/eungchaeungcha/juang/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.eungchaeungcha.juang.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## ✅ 운영환경 설정
close #6 

<br>

## ✅ 작업 내용
- 클라이언트 서버에서 요청을 할 수 있도록 CORS 를 허용해주었습니다. 
- @Configuration 을 통해 전역적으로 설정되도록 해주었으며, WebMvcConfigurer 의 `addCorsMapping` 메소드를 구현하였습니다.
- `addMapping("/**")`
    - 모든 API uri 에 대해서 접근할 수 있도록 허용
- `allowedMethods` 를 다음과 같이 지정해주었습니다. 
    - GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH
- `allowedHeaders(*)`
    - 브라우저에게 명시할 헤더 설정
- `allowCredentials(true)`
    - 클라이언트에서 받은 쿠키를 받을 수 있도록 설정 