### PR TITLE
인증/인가 예외 처리를 할 수 있다.

### DIFF
--- a/src/main/java/com/eungchaeungcha/juang/common/CommonErrorCode.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/CommonErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
 
+    INVALID_USERNAME_AND_PASSWORD(HttpStatus.UNAUTHORIZED, "Invalid username and password"),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
     FAMILY_NOT_FOUND(HttpStatus.NOT_FOUND, "Family not found"),

--- a/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -30,10 +31,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(makeErrorResponse(e, errorCode));
     }
-    @ExceptionHandler
+
+    @ExceptionHandler(BusinessException.class)
     public ResponseEntity<Object> handleBusinessLogicException(BusinessException e) {
 
         ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(makeErrorResponse(errorCode));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Object> handleAuthenticationException() {
+
+        ErrorCode errorCode = CommonErrorCode.INVALID_USERNAME_AND_PASSWORD;
 
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/com/eungchaeungcha/juang/config/ApplicationConfig.java
+++ b/src/main/java/com/eungchaeungcha/juang/config/ApplicationConfig.java
@@ -6,10 +6,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -37,7 +37,7 @@ public class ApplicationConfig {
     @Bean
     public UserDetailsService userDetailsService() {
         return username -> userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+                .orElseThrow(() -> new BadCredentialsException("invalid username"));
     }
 
     @Bean

--- a/src/main/java/com/eungchaeungcha/juang/config/ApplicationConfig.java
+++ b/src/main/java/com/eungchaeungcha/juang/config/ApplicationConfig.java
@@ -37,7 +37,7 @@ public class ApplicationConfig {
     @Bean
     public UserDetailsService userDetailsService() {
         return username -> userRepository.findByUsername(username)
-                .orElseThrow(() -> new BadCredentialsException("invalid username"));
+                .orElseThrow(() -> new BadCredentialsException("Invalid username"));
     }
 
     @Bean

--- a/src/main/java/com/eungchaeungcha/juang/config/JwtService.java
+++ b/src/main/java/com/eungchaeungcha/juang/config/JwtService.java
@@ -50,7 +50,7 @@ public class JwtService {
                 .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 365))
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
     }


### PR DESCRIPTION
## ✅ 인증/인가 예외 처리
close #1 

<br>

## ✅ 작업 내용
- 아이디/비밀번호로 요청 시 실패에 대한 예외처리를 해주었습니다.
    - `AuthenticationException` 을 상속받는 `BadCredentialException` 이 발생했을 때 AOP 기반으로 작동되는 핸들러를 구현하여 custom 한 ErrorResponse 및 status 를 지정하도록 하였습니다. 
    - 아이디가 유효하지 않는 경우, 아이디와 비밀번호가 일치하지 않는 경우 모두 `BadCredentialException` 을 던지도록 하였습니다. 
- `accessToken` 만료기간을 설정해주었습니다. 
    - `refreshToken` 은 추후에 설정할 예정입니다.  