### PR TITLE
로그인 실패 예외 처리

### DIFF
--- a/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/eungchaeungcha/juang/common/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -42,7 +43,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(makeErrorResponse(errorCode));
     }
 
-    @ExceptionHandler(BadCredentialsException.class)
+    @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<Object> handleAuthenticationException() {
 
         ErrorCode errorCode = CommonErrorCode.INVALID_USERNAME_AND_PASSWORD;


### PR DESCRIPTION
## ✅ 로그인 실패 예외 처리
close #1 

<br>

## ✅ 작업 내용
- 아이디/비밀번호로 요청 시 실패에 대한 예외처리를 해주었습니다.
    - `AuthenticationException` 에 대해 AOP 기반으로 작동되는 핸들러를 구현하여 custom 한 ErrorResponse 및 status 를 지정하도록 하였습니다. 
    - 아이디가 유효하지 않는 경우, 아이디와 비밀번호가 일치하지 않는 경우 모두 `BadCredentialException` 을 던지도록 하였습니다. 