### PR TITLE
20250305_2 배포

### DIFF
--- a/src/main/java/com/eungchaeungcha/juang/controller/UserController.java
+++ b/src/main/java/com/eungchaeungcha/juang/controller/UserController.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -62,5 +64,16 @@ public class UserController {
         UserResponseDTO response = userService.updateFamily(username, request.code());
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/families/{familyId}")
+    private ResponseEntity<List<UserResponseDTO>> get(
+            @PathVariable Long familyId
+    ) {
+
+        List<UserResponseDTO> response = userService.find(familyId);
+
+        return ResponseEntity.ok(response);
+
     }
 }

--- a/src/main/java/com/eungchaeungcha/juang/repository/UserRepository.java
+++ b/src/main/java/com/eungchaeungcha/juang/repository/UserRepository.java
@@ -3,9 +3,11 @@ package com.eungchaeungcha.juang.repository;
 import com.eungchaeungcha.juang.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUsername(String username);
     Boolean existsByUsername(String username);
+    List<UserEntity> findAllByFamilyId(Long familyId);
 }

--- a/src/main/java/com/eungchaeungcha/juang/service/FamilyService.java
+++ b/src/main/java/com/eungchaeungcha/juang/service/FamilyService.java
@@ -1,5 +1,6 @@
 package com.eungchaeungcha.juang.service;
 
+import com.eungchaeungcha.juang.common.BusinessException;
 import com.eungchaeungcha.juang.common.CommonErrorCode;
 import com.eungchaeungcha.juang.domain.Family;
 import com.eungchaeungcha.juang.dto.FamilyRequestDTO;
@@ -38,6 +39,12 @@ public class FamilyService {
                 .orElseThrow(() -> new RuntimeException(CommonErrorCode.FAMILY_NOT_FOUND.name()));
 
         return familyEntity.toDomain();
+    }
+
+    public void exist(Long familyId) {
+        if(!familyRepository.existsById(familyId)){
+            throw new BusinessException(CommonErrorCode.FAMILY_NOT_FOUND);
+        }
     }
 
     private String generateUniqueCode() {

--- a/src/main/java/com/eungchaeungcha/juang/service/UserService.java
+++ b/src/main/java/com/eungchaeungcha/juang/service/UserService.java
@@ -1,5 +1,6 @@
 package com.eungchaeungcha.juang.service;
 
+import com.eungchaeungcha.juang.common.BusinessException;
 import com.eungchaeungcha.juang.common.CommonErrorCode;
 import com.eungchaeungcha.juang.domain.Family;
 import com.eungchaeungcha.juang.domain.User;
@@ -10,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -68,5 +72,19 @@ public class UserService {
     public UserEntity find(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException(CommonErrorCode.USER_NOT_FOUND.name()));
+    }
+
+    public List<UserResponseDTO> find(Long familyId) {
+        familyService.exist(familyId);
+
+        List<UserEntity> userList = userRepository.findAllByFamilyId(familyId);
+
+        if (userList.isEmpty()) {
+            throw new BusinessException(CommonErrorCode.USER_NOT_FOUND);
+        }
+
+        return userList
+                .stream().map(userEntity -> UserResponseDTO.from(userEntity.toDomain()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/eungchaeungcha/juang/service/UserServiceTest.java
+++ b/src/test/java/com/eungchaeungcha/juang/service/UserServiceTest.java
@@ -1,0 +1,101 @@
+package com.eungchaeungcha.juang.service;
+
+import com.eungchaeungcha.juang.common.BusinessException;
+import com.eungchaeungcha.juang.common.CommonErrorCode;
+import com.eungchaeungcha.juang.domain.Role;
+import com.eungchaeungcha.juang.dto.UserResponseDTO;
+import com.eungchaeungcha.juang.entity.UserEntity;
+import com.eungchaeungcha.juang.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FamilyService familyService;
+
+    @InjectMocks
+    private UserService userService;
+
+
+    @Test
+    @DisplayName("family id 로 user 리스트 조회 테스트")
+    public void findUserListByFamilyId() {
+        //given
+        int familySize = 4;
+        Long familyId = 1L;
+        List<UserEntity> userList = new ArrayList<>();
+        for (long i = 0; i < familySize; i++) {
+            UserEntity userEntity = createUserEntity(i, familyId);
+            userList.add(userEntity);
+        }
+
+        doNothing().when(familyService).exist(familyId);
+        when(userRepository.findAllByFamilyId(1L)).thenReturn(userList);
+
+        // when
+        List<UserResponseDTO> response = userService.find(1L);
+
+        // then
+        assertThat(response.size()).isEqualTo(familySize);
+        assertThat(response.get(0).id()).isEqualTo(0L);
+        assertThat(response.get(0).familyId()).isEqualTo(familyId);
+        assertThat(response.get(1).id()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("family id 로 user 리스트 조회 시 예외 발생 테스트")
+    public void findUserListByFamilyId_empty() {
+        //given
+        Long familyId = 99L;
+        doThrow(new BusinessException(CommonErrorCode.FAMILY_NOT_FOUND))
+                .when(familyService).exist(familyId);
+
+        // when & then
+        assertThatThrownBy(() -> userService.find(familyId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(CommonErrorCode.FAMILY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("family id 로 user 리스트 조회 시 user 가 없을 때 예외 발생")
+    public void findUserListByFamilyId_userNotFound() {
+        // given
+        Long familyId = 1L;
+        doNothing().when(familyService).exist(familyId);
+        when(userRepository.findAllByFamilyId(familyId)).thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> userService.find(familyId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(CommonErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    private UserEntity createUserEntity(Long id, Long familyId) {
+        return UserEntity.builder()
+                .id(id)
+                .username("username")
+                .password("password")
+                .nickName("nickName")
+                .familyId(familyId)
+                .characterId(1L)
+                .role(Role.ROLE_USER)
+                .build();
+    }
+
+}


### PR DESCRIPTION
* add: familyId 를 갖고 있는 user 리스트 조회

- familyId 에 해당하는 family 가 없는 경우 FAMILY_NOT_FOUND 예외 발생하도록 하였습니다.
- familyId 에 해당하는 user 가 없는 경우 USER_NOT_FOUND 예외 발생하도록 하였습니다.

* test: familyId 로 userList 조회 service 단위 테스트

- familyId 에 속한 user 들의 목록을 정상 조회 테스트
- familyId 에 해당하는 family 가 없는 경우 예외 발생 테스트
- familyId 에 해당하는 user 가 없는 경우 예외 발생 테스트